### PR TITLE
bugfix: remove output size limit

### DIFF
--- a/sduoj-judger-service/src/main/java/cn/edu/sdu/qd/oj/judger/handler/AbstractSubmissionHandler.java
+++ b/sduoj-judger-service/src/main/java/cn/edu/sdu/qd/oj/judger/handler/AbstractSubmissionHandler.java
@@ -165,6 +165,7 @@ public abstract class AbstractSubmissionHandler {
     private void releaseWorkspace() throws SystemErrorException {
         try {
             ProcessUtils.chmod(workspaceDir + "/*", "711");
+            // TODO: 考虑删除文件
         } catch (Exception e) {
             throw new SystemErrorException("Can not release workspace:\n" + e.toString());
         }

--- a/sduoj-judger-service/src/main/java/cn/edu/sdu/qd/oj/judger/handler/AbstractSubmissionHandler.java
+++ b/sduoj-judger-service/src/main/java/cn/edu/sdu/qd/oj/judger/handler/AbstractSubmissionHandler.java
@@ -23,6 +23,7 @@ import cn.edu.sdu.qd.oj.submit.enums.SubmissionJudgeResult;
 import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.amqp.AmqpException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
@@ -128,6 +129,12 @@ public abstract class AbstractSubmissionHandler {
         }
         // 更新 result 并 ack
         if (updateReqDTO != null) {
+            // judgeLog 字段长度限制
+            String judgeLog = updateReqDTO.getJudgeLog();
+            if (StringUtils.isNotBlank(judgeLog)) {
+                updateReqDTO.setJudgeLog(judgeLog.substring(0, Math.min(judgeLog.length(), 48 * 1024))); // 限制 48K judgeLog
+            }
+            // 多次尝试
             for (int i = 0; i < 5; i++) {
                 try {
                     // 更新 submission result

--- a/sduoj-judger-service/src/main/java/cn/edu/sdu/qd/oj/judger/handler/IOSubmissionHandler.java
+++ b/sduoj-judger-service/src/main/java/cn/edu/sdu/qd/oj/judger/handler/IOSubmissionHandler.java
@@ -151,7 +151,7 @@ public class IOSubmissionHandler extends AbstractSubmissionHandler {
                     new Argument(SandboxArgument.MAX_REAL_TIME, compileConfig.getMaxRealTime()),
                     new Argument(SandboxArgument.MAX_MEMORY, compileConfig.getMaxMemory() * 1024L),
                     new Argument(SandboxArgument.MAX_STACK, 128 * 1024 * 1024L),
-                    new Argument(SandboxArgument.MAX_OUTPUT_SIZE, 48 * 1024), // 48K
+                    new Argument(SandboxArgument.MAX_OUTPUT_SIZE, 20 * 1024 * 1024), // 20MB
                     new Argument(SandboxArgument.EXE_PATH, _commands[0]),
                     new Argument(SandboxArgument.EXE_ARGS, Arrays.copyOfRange(_commands, 1, _commands.length)),
                     new Argument(SandboxArgument.EXE_ENVS, exeEnvs),


### PR DESCRIPTION
let time-limit to kill OLE program now.

For scenario reasons, we will support output limit field not in problemConfig but judgeTemplateConfig.