### PR TITLE
bugfix: locale&language in docker-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:18.04
 MAINTAINER SDUOJ-dev
 
+ENV LANG C.UTF-8
+
 COPY docker/sources.list /etc/apt/sources.list
 COPY docker/mavenSettings.xml /usr/share/maven/conf/settings.xml
 COPY docker/testlib /testlib.h


### PR DESCRIPTION
Cause:
* Submission coding error for chinese char.
* In docker cmd, can't input chinese char.

https://hub.docker.com/_/Ubuntu :

> Given that it is a minimal install of Ubuntu, this image only includes the C, C.UTF-8, and POSIX locales by default. For most uses requiring a UTF-8 locale, C.UTF-8 is likely sufficient (-e LANG=C.UTF-8 or ENV LANG C.UTF-8).

Test Passed!
